### PR TITLE
more dual face cards to ignore from scryfall, added mapping for bab c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 dist
 multiple_names.json
 __pycache__
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ In both cases, it will give you a new csv, named `deckbox_import.csv` in the dir
 2. Showcase and extended art cards - TCGplayer suffixes these with `(Extended Art)` or `(Showcase)`. If the script finds these terms, it just deletes them. They're unnecessary as they have different collector's numbers.
 
 3. Odd sets from Magic's history - I did my best here, but some of the older sets didn't quite line up. Some I just didn't have enough information on, some looked like categories of multiple sets, and some actually look like they map to multple different sets in deckbox. If you hit some of these, manual correction is probably the best bet for now, but if you have a solution, feel free to share!
+
+## Contributing
+When making pull requests please format Python code using Black [black](https://github.com/psf/black) 
+
+```sh
+# installing black
+pip install black
+```
+
+```sh
+# running black
+black tcg-to-deckbox.py
+```

--- a/src/replacements.config
+++ b/src/replacements.config
@@ -71,7 +71,6 @@ WPN & Gateway Promos=WPN/Gateway
 Promo Pack: Strixhaven=Promo Pack: Strixhaven: School of Mages
 Strixhaven: Mystical Archives=Strixhaven Mystical Archive
 Time Spiral: Remastered=Time Spiral Remastered
-Promo Pack: Strixhaven=Promo pack: Strixhaven: School of Mages
 Commander: Adventures in the Forgotten Realms=Adventures in the Forgotten Realms Commander
 Commander: Innistrad: Midnight Hunt=Innistrad: Midnight Hunt Commander
 Commander: Innistrad: Crimson Vow=Innistrad: Crimson Vow Commander

--- a/src/replacements.config
+++ b/src/replacements.config
@@ -82,3 +82,12 @@ Tamiyo's Journal (Entry 546)=Tamiyo's Journal
 Tamiyo's Journal (Entry 855)=Tamiyo's Journal
 Tamiyo's Journal (Entry 434)=Tamiyo's Journal
 Tamiyo's Journal (Entry 653)=Tamiyo's Journal
+;; Crimson Vow Alternative Art
+Sisters of the Undead - Olivia, Crimson Bride=Olivia, Crimson Bride
+Mina Harker - Thalia, Guardian of Thraben=Thalia, Guardian of Thraben
+Abraham Van Helsing - Savior of Ollenbock=Savior of Ollenbock
+Dracula, Lord of Blood - Voldaren Bloodcaster=Voldaren Bloodcaster
+Dracula the Voyager - Edgar, Charmed Groom=Edgar, Charmed Groom
+Dracula, Blood Immortal - Falkenrath Forebear=Falkenrath Forebear
+;; Ikoria Alternative Art
+Destoroyah, Perfect Lifeform - Everquill Phoenix=Everquill Phoenix

--- a/src/tcg-to-deckbox.py
+++ b/src/tcg-to-deckbox.py
@@ -16,17 +16,31 @@ import json
 # Constants
 MULTI_NAMES_FILE = "multiple_names.json"
 SCRYFALL_URL = "https://api.scryfall.com/cards/search?order=cmc&q=%28is%3Adoublesided%20OR%20is%3Asplit%20OR%20is%3Aadventure%29%20%20AND%20game%3Apaper%20AND%20-is%3Atoken%20AND%20-set%3ACMB1%20AND%20-is%3Aextra"
-MULTI_NAMES_IGNORE = ["Nicol Bolas, the Ravager","Hadana's Climb", "Treasure Map", "Storm the Vault"]
+MULTI_NAMES_IGNORE = [
+    "Nicol Bolas, the Ravager",
+    "Hadana's Climb",
+    "Treasure Map",
+    "Storm the Vault",
+]
 
-#global vars
+# global vars
 scryfall_data = {}
 
-#Global replacement helpers
-ixalan_bab = ["Legion's Landing", "Search for Azcanta", "Arguel's Blood Fast", "Vance's Blasting Cannons", "Growing Rites of Itlimoc", "Conqueror's Galleon", "Dowsing Dagger", "Primal Amulet", "Thaumatic Compass", "Treasure Map"]
+# Global replacement helpers
+ixalan_bab = [
+    "Legion's Landing",
+    "Search for Azcanta",
+    "Arguel's Blood Fast",
+    "Vance's Blasting Cannons",
+    "Growing Rites of Itlimoc",
+    "Conqueror's Galleon",
+    "Dowsing Dagger",
+    "Primal Amulet",
+    "Thaumatic Compass",
+    "Treasure Map",
+]
 
-bab_mapping = {
-    "Impervious Greatwurm": "Guilds of Ravnica"
-}
+bab_mapping = {"Impervious Greatwurm": "Guilds of Ravnica"}
 
 # Get rid of the root TK window, we don't need it.
 root = tk.Tk()
@@ -34,7 +48,7 @@ root.withdraw()
 
 
 def fetch_multiple_names(uri, page=1):
-    print('Begin: Download %s, page %s of results' % (uri, page))
+    print("Begin: Download %s, page %s of results" % (uri, page))
     try:
         with requests.get(uri) as response:
             tmp_scryfall_data = response.json()
@@ -48,8 +62,9 @@ def fetch_multiple_names(uri, page=1):
             if "next_page" in tmp_scryfall_data:
                 fetch_multiple_names(tmp_scryfall_data["next_page"], page + 1)
     except Exception:
-        print('Exception: Was unable to download %s, page %s of results' % (uri, page))
+        print("Exception: Was unable to download %s, page %s of results" % (uri, page))
         print(Exception)
+
 
 # Utility function to replace strings in the csv from the replacements.config file.
 
@@ -72,14 +87,16 @@ def getPathPrefix():
 # Check to see if we have DFC/Split/etc card names from scryfall and if it is up to date
 try:
     multi_files_last_updated = os.path.getmtime(MULTI_NAMES_FILE)
-    print("%s last modified: %s" %
-          (MULTI_NAMES_FILE, time.ctime(multi_files_last_updated)))
+    print(
+        "%s last modified: %s"
+        % (MULTI_NAMES_FILE, time.ctime(multi_files_last_updated))
+    )
     now = time.time()
-    last_week = now - 60*60*24*7
+    last_week = now - 60 * 60 * 24 * 7
     if multi_files_last_updated < last_week:
         print("File %s is stale - updating..." % (MULTI_NAMES_FILE))
         fetch_multiple_names(SCRYFALL_URL)
-        with open(MULTI_NAMES_FILE, 'w') as multiple_names:
+        with open(MULTI_NAMES_FILE, "w") as multiple_names:
             json.dump(scryfall_data, multiple_names)
         print("Done!")
     else:
@@ -91,7 +108,7 @@ try:
 except Exception:
     print("File %s not found - creating..." % (MULTI_NAMES_FILE))
     fetch_multiple_names(SCRYFALL_URL)
-    with open(MULTI_NAMES_FILE, 'w') as multiple_names:
+    with open(MULTI_NAMES_FILE, "w") as multiple_names:
         json.dump(scryfall_data, multiple_names)
     print("Done!")
 
@@ -100,23 +117,36 @@ except Exception:
 GUI = False
 if len(sys.argv) < 2:
     GUI = True
-    FILE = filedialog.askopenfilename(title="Select your TCGPlayer app export file", filetypes=[
-        ("TCGPlayer exports", ".csv"), ("All files", "*.*")])
+    FILE = filedialog.askopenfilename(
+        title="Select your TCGPlayer app export file",
+        filetypes=[("TCGPlayer exports", ".csv"), ("All files", "*.*")],
+    )
     if len(FILE) == 0:
-        messagebox.showerror(title="Input file not provided",
-                             message="You must pass the TCGPlayer csv export file to this program.")
+        messagebox.showerror(
+            title="Input file not provided",
+            message="You must pass the TCGPlayer csv export file to this program.",
+        )
         sys.exit()
 else:
     FILE = sys.argv[1]
 
-skipcolumns = ["Simple Name", "Set Code", "Rarity",
-               "Product ID", "SKU", "Price", "Price Each"]
+skipcolumns = [
+    "Simple Name",
+    "Set Code",
+    "Rarity",
+    "Product ID",
+    "SKU",
+    "Price",
+    "Price Each",
+]
 outputFile = "deckbox_import.csv"
 
 configParser = configparser.ConfigParser(delimiters="=")
 configParser.read(os.path.join(getPathPrefix(), "replacements.config"))
 
-with open(FILE, newline="") as tcgcsvfile, open(outputFile, "w", newline="") as deckboxcsvfile:
+with open(FILE, newline="") as tcgcsvfile, open(
+    outputFile, "w", newline=""
+) as deckboxcsvfile:
 
     try:
         csv.Sniffer().sniff(tcgcsvfile.read(4096), delimiters=",")
@@ -124,7 +154,9 @@ with open(FILE, newline="") as tcgcsvfile, open(outputFile, "w", newline="") as 
     except:
         if GUI:
             messagebox.showerror(
-                title="Invalid input file", message="The file selected does not appear to be a valid CSV file.")
+                title="Invalid input file",
+                message="The file selected does not appear to be a valid CSV file.",
+            )
         else:
             print("The file passed does not appear to be a valid CSV file.")
         sys.exit()
@@ -141,14 +173,15 @@ with open(FILE, newline="") as tcgcsvfile, open(outputFile, "w", newline="") as 
     headersdeckbox = [x for x in headerstcg if x not in skipcolumns]
 
     csvwriter = csv.DictWriter(
-        deckboxcsvfile, quoting=csv.QUOTE_ALL, fieldnames=headersdeckbox)
+        deckboxcsvfile, quoting=csv.QUOTE_ALL, fieldnames=headersdeckbox
+    )
     csvwriter.writeheader()
     for row in csvreader:
-        skip_scryfall_names=False
-        
+        skip_scryfall_names = False
+
         # Don't bother with columns that are going to be ignored anyways
         for skippable in skipcolumns:
-            row.pop(skippable, '')
+            row.pop(skippable, "")
 
         # Map the printing column to the Foil column
         if row["Foil"] == "Normal":
@@ -180,17 +213,17 @@ with open(FILE, newline="") as tcgcsvfile, open(outputFile, "w", newline="") as 
         # Buy a Box Promos worled a little differently with Ixalan
         if row["Name"] in ixalan_bab and row["Edition"] == "Buy-A-Box Promos":
             row["Edition"] = "Black Friday Treasure Chest Promos"
-            skip_scryfall_names=True
+            skip_scryfall_names = True
         # Handle other BaB promo cards
         if row["Name"] in bab_mapping and row["Edition"] == "Buy-A-Box Promos":
             row["Edition"] = bab_mapping[row["Name"]]
         # Handle Mystery Booster Test Cards, the 2021 release differentiates by Edition
         # on deckbox, while tcgplayer differentiates by name appending '(No PW Symbol)'
-        if "(No PW Symbol)" in row["Name"] and row["Edition"] == "Mystery Booster: Convention Edition Exclusives":
+        if (
+            "(No PW Symbol)" in row["Name"]
+            and row["Edition"] == "Mystery Booster: Convention Edition Exclusives"
+        ):
             row["Edition"] = "Mystery Booster Playtest Cards 2021"
-            
-        # For BFZ lands...there's no differentiator from the full arts and the non full arts.
-        row["Name"] = row["Name"].replace(" - Full Art", "")
 
         row["Name"] = re.sub(r" \(.*\)", "", row["Name"])
         replace_strings(row, "NAMES", "Name")
@@ -208,9 +241,9 @@ with open(FILE, newline="") as tcgcsvfile, open(outputFile, "w", newline="") as 
 
 # All Done!
 successMsg = "Your import file for deckbox.org is available here: %s" % os.path.abspath(
-    outputFile)
+    outputFile
+)
 if GUI:
-    messagebox.showinfo(
-        title="Conversion completed successfully!", message=successMsg)
+    messagebox.showinfo(title="Conversion completed successfully!", message=successMsg)
 else:
     print(successMsg)

--- a/src/tcg-to-deckbox.py
+++ b/src/tcg-to-deckbox.py
@@ -16,7 +16,7 @@ import json
 # Constants
 MULTI_NAMES_FILE = "multiple_names.json"
 SCRYFALL_URL = "https://api.scryfall.com/cards/search?order=cmc&q=%28is%3Adoublesided%20OR%20is%3Asplit%20OR%20is%3Aadventure%29%20%20AND%20game%3Apaper%20AND%20-is%3Atoken%20AND%20-set%3ACMB1%20AND%20-is%3Aextra"
-MULTI_NAMES_IGNORE = ["Nicol Bolas, the Ravager","Hadana's Climb"]
+MULTI_NAMES_IGNORE = ["Nicol Bolas, the Ravager","Hadana's Climb", "Treasure Map", "Storm the Vault"]
 
 #global vars
 scryfall_data = {}
@@ -24,6 +24,9 @@ scryfall_data = {}
 #Global replacement helpers
 ixalan_bab = ["Legion's Landing", "Search for Azcanta", "Arguel's Blood Fast", "Vance's Blasting Cannons", "Growing Rites of Itlimoc", "Conqueror's Galleon", "Dowsing Dagger", "Primal Amulet", "Thaumatic Compass", "Treasure Map"]
 
+bab_mapping = {
+    "Impervious Greatwurm": "Guilds of Ravnica"
+}
 
 # Get rid of the root TK window, we don't need it.
 root = tk.Tk()
@@ -178,12 +181,14 @@ with open(FILE, newline="") as tcgcsvfile, open(outputFile, "w", newline="") as 
         if row["Name"] in ixalan_bab and row["Edition"] == "Buy-A-Box Promos":
             row["Edition"] = "Black Friday Treasure Chest Promos"
             skip_scryfall_names=True
-
+        # Handle other BaB promo cards
+        if row["Name"] in bab_mapping and row["Edition"] == "Buy-A-Box Promos":
+            row["Edition"] = bab_mapping[row["Name"]]
             
         # For BFZ lands...there's no differentiator from the full arts and the non full arts.
         row["Name"] = row["Name"].replace(" - Full Art", "")
 
-        row["Name"] = re.sub(r" \([^)(]+\)$", "", row["Name"])
+        row["Name"] = re.sub(r" \(.*\)", "", row["Name"])
         replace_strings(row, "NAMES", "Name")
         if skip_scryfall_names == False and row["Name"] in scryfall_data:
             row["Name"] = scryfall_data[row["Name"]]

--- a/src/tcg-to-deckbox.py
+++ b/src/tcg-to-deckbox.py
@@ -184,6 +184,10 @@ with open(FILE, newline="") as tcgcsvfile, open(outputFile, "w", newline="") as 
         # Handle other BaB promo cards
         if row["Name"] in bab_mapping and row["Edition"] == "Buy-A-Box Promos":
             row["Edition"] = bab_mapping[row["Name"]]
+        # Handle Mystery Booster Test Cards, the 2021 release differentiates by Edition
+        # on deckbox, while tcgplayer differentiates by name appending '(No PW Symbol)'
+        if "(No PW Symbol)" in row["Name"] and row["Edition"] == "Mystery Booster: Convention Edition Exclusives":
+            row["Edition"] = "Mystery Booster Playtest Cards 2021"
             
         # For BFZ lands...there's no differentiator from the full arts and the non full arts.
         row["Name"] = row["Name"].replace(" - Full Art", "")

--- a/src/tcg-to-deckbox.py
+++ b/src/tcg-to-deckbox.py
@@ -21,6 +21,9 @@ MULTI_NAMES_IGNORE = [
     "Hadana's Climb",
     "Treasure Map",
     "Storm the Vault",
+    "Hanweir Militia Captain",
+    "Legion's Landing",
+    "Geier Reach Bandit",
 ]
 
 # global vars
@@ -40,7 +43,12 @@ ixalan_bab = [
     "Treasure Map",
 ]
 
-bab_mapping = {"Impervious Greatwurm": "Guilds of Ravnica"}
+bab_mapping = {
+    "Impervious Greatwurm": "Guilds of Ravnica",
+    "Kenrith, the Returned King": "Throne of Eldraine",
+    "Realmwalker": "Kaldheim",
+    "Vorpal Sword": "Adventures in the Forgotten Realms",
+}
 
 # Get rid of the root TK window, we don't need it.
 root = tk.Tk()
@@ -194,14 +202,6 @@ with open(FILE, newline="") as tcgcsvfile, open(
         replace_strings(row, "LANGUAGES", "Language")
 
         # Map Specific Card Names, and drop extra tidbits
-        # alternative art/name for Dracula cards
-        row["Name"] = row["Name"].replace("Sisters of the Undead - ", "")
-        row["Name"] = row["Name"].replace("Mina Harker - ", "")
-        row["Name"] = row["Name"].replace("Abraham Van Helsing - ", "")
-        row["Name"] = row["Name"].replace("Dracula, Lord of Blood - ", "")
-        row["Name"] = row["Name"].replace("Dracula the Voyager - ", "")
-        row["Name"] = row["Name"].replace("Dracula, Blood Immortal - ", "")
-
         # For BFZ lands...there's no differentiator from the full arts and the non full arts.
         row["Name"] = row["Name"].replace(" - Full Art", "")
 
@@ -214,9 +214,6 @@ with open(FILE, newline="") as tcgcsvfile, open(
         if row["Name"] in ixalan_bab and row["Edition"] == "Buy-A-Box Promos":
             row["Edition"] = "Black Friday Treasure Chest Promos"
             skip_scryfall_names = True
-        # Handle other BaB promo cards
-        if row["Name"] in bab_mapping and row["Edition"] == "Buy-A-Box Promos":
-            row["Edition"] = bab_mapping[row["Name"]]
         # Handle Mystery Booster Test Cards, the 2021 release differentiates by Edition
         # on deckbox, while tcgplayer differentiates by name appending '(No PW Symbol)'
         if (
@@ -229,6 +226,9 @@ with open(FILE, newline="") as tcgcsvfile, open(
         replace_strings(row, "NAMES", "Name")
         if skip_scryfall_names == False and row["Name"] in scryfall_data:
             row["Name"] = scryfall_data[row["Name"]]
+        # Fix edition for Buy-A-Box Promos
+        if row["Name"] in bab_mapping and row["Edition"] == "Buy-A-Box Promos":
+            row["Edition"] = bab_mapping[row["Name"]]
 
         # remove weird symbols from card numbers
         row["Card Number"] = re.sub(r"[*★]", "", row["Card Number"])


### PR DESCRIPTION
…ards, updated regex for cases with multiple groups of parenthesis

Needed to make more adjustments for another set up cards I scanned.

I'm playing around with an idea to cross-reference the scryfall names by hitting "https://deckbox.org/mtg/{name}" and if that returns a 302 (it redirects to the home page if not found) then defaulting to the single name.  That should remove the need for the "MULTI_NAMES_IGNORE" that I had added. I wanted to see what you thought of that before I spent too much time.

Also I'm curious if you have a linter preference?  I'd like to have my editor lint on save, but I don't want to push up a bunch of formatting changes if they don't match your preferred linting rules.