### PR TITLE
Fix for The List cards and Commander cards

### DIFF
--- a/src/tcg-to-deckbox.py
+++ b/src/tcg-to-deckbox.py
@@ -25,6 +25,10 @@ def getPathPrefix():
         prefix = os.path.abspath(".")
     return prefix
 
+def removePrefix( text, prefix ):
+    if text.startswith( prefix ):
+        return text[ len(prefix): ]
+    return text
 
 # Get our input
 GUI=False
@@ -106,6 +110,11 @@ with open(FILE, newline="") as tcgcsvfile,open(outputFile, "w", newline="") as d
 
         # Map Specific Edition Names
         replace_strings(row, "EDITONS", "Edition")
+
+        # Convert 'Commander: ' to append ' Commander' as a suffix
+        if row["Edition"].startswith( "Commander: "):
+            row["Edition"] = removePrefix( row["Edition"], "Commander: " );
+            row["Edition"] = "".join( [row["Edition"], " Commander"] )
 
         # write the converted output
         csvwriter.writerow(row)

--- a/src/tcg-to-deckbox.py
+++ b/src/tcg-to-deckbox.py
@@ -116,6 +116,10 @@ with open(FILE, newline="") as tcgcsvfile,open(outputFile, "w", newline="") as d
             row["Edition"] = removePrefix( row["Edition"], "Commander: " );
             row["Edition"] = "".join( [row["Edition"], " Commander"] )
 
+        # Convert 'The List Reprints' to  just 'The List' as deckbox expects
+        if row["Edition"] == "The List Reprints":
+            row["Edition"] = "The List"
+
         # write the converted output
         csvwriter.writerow(row)
 


### PR DESCRIPTION
TCG output CSV with 'Commander: <Edition>' and Deckbox expects '<Edition> Commander'.  TCG also outputs the Edition as 'The List Reprints' and Deckbox expects just 'The List' as the edition.

These changes address both issues for easier direct importing after executing tcg-to-deckbox.